### PR TITLE
Disable spellcheck for search input

### DIFF
--- a/app/scripts/kunden/overview/kundenoverview.html
+++ b/app/scripts/kunden/overview/kundenoverview.html
@@ -6,7 +6,7 @@
           <h3  class="panel-title"><span class="navbar-brand" translate>Kunden</span>
             <form class="navbar-form pull-right" role="search">
               <div class="form-group">
-                <input type="text" class="form-control" placeholder="{{'Suche in Übersicht...'|translate}}" ng-model="search.query">
+                <input type="text" spellcheck="false" class="form-control" placeholder="{{'Suche in Übersicht...'|translate}}" ng-model="search.query">
                 <oo-actions-button model="model" actions="actions">{{'Kunde erstellen'|translate}}</oo-actions-button>
               </div>
             </form>


### PR DESCRIPTION
The browsers correcting the input of the search field modifies the query. This can be confusing to the user because it might happen unnoticed. For a search field the feature should be disabled especially when the input is not expected to be in a dictionary like the name of a person.